### PR TITLE
🛡️ Sentinel: [Medium] Fix swallowed errors and unquoted variables in bring.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2024-03-18: [Medium] Swallowed errors in bash scripts mask underlying failures.

--- a/bring.sh
+++ b/bring.sh
@@ -1,9 +1,12 @@
+#!/usr/bin/env bash
+source lib/error_reporting.sh || true
+
 function bring() {
-    srcdir="$(dirname $1)"
+    srcdir="$(dirname "$1")"
     destdir=".$srcdir"
-    srcfile=$1
-    mkdir -p "$destdir"
-    cp "$srcfile" "$destdir" -r && echo "Copiado $srcfile para $destdir"
+    srcfile="$1"
+    mkdir -p "$destdir" || { report_error "Failed to create directory $destdir"; return 1; }
+    cp "$srcfile" "$destdir" -r && echo "Copiado $srcfile para $destdir" || { report_error "Failed to copy $srcfile to $destdir"; return 1; }
 }
 
 # bring /etc/systemd/system/screenlock.service
@@ -25,4 +28,4 @@ bring ~/.zshrc
 bring ~/environment
 bring ~/.PlayOnLinux/wineprefix/liberar_barra.sh
 
-pacman -Qe > pacman-explicit.txt
+pacman -Qe > pacman-explicit.txt || report_error "Failed to execute pacman -Qe"

--- a/lib/error_reporting.sh
+++ b/lib/error_reporting.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Centralized error reporting
+function report_error() {
+    local message="$1"
+    echo "[ERROR] $message" >&2
+}


### PR DESCRIPTION
### Severity: Medium

### Vulnerability
The `bring.sh` script previously ignored errors occurring during file operations (`mkdir -p`, `cp`, and `pacman`). An ignored error here implies a failure to back up dotfiles, creating a silent condition where users think their files are safe, but they are not. Additionally, arguments were unquoted (`$1`), causing potential word-splitting/globbing issues.

### Impact
Silent failure on important dotfiles backup procedures. A user might miss backing up their environment entirely because the script swallowed errors and exited with success.

### Fix
- Replaced unquoted variables with quoted ones to prevent word splitting/globbing issues (`$1` -> `"$1"`).
- Added error handling (`|| report_error "..."`) to `mkdir`, `cp`, and `pacman` commands.
- Created `lib/error_reporting.sh` with a centralized `report_error` function to capture all unexpected failures per project conventions.
- Logged the vulnerability pattern in `.jules/sentinel.md`.

### Verification
- Tested syntax via `bash -n bring.sh`.
- Pre-commit verifications confirm changes only occurred in the allowed scope.

### Assumptions
- A dotfiles repo requires consistent error reporting. We assumed `lib/error_reporting.sh` should be created to centralize stderr logging.

### Alternatives Not Chosen
- Continuing to use inline `echo` for error handling, which violates the centralized error handling global instruction.

### How To Pivot
- If a different logging structure is preferred, `lib/error_reporting.sh` can be modified without altering `bring.sh`.

### Next Knobs
- Adjust the `report_error` function to write to a log file instead of `stderr`.
- Extend error handling coverage to other bash scripts in the repository.

---
*PR created automatically by Jules for task [18324032681093231282](https://jules.google.com/task/18324032681093231282) started by @lucasew*